### PR TITLE
Fixed fatal caused by Mkdir instead of MkdirAll

### DIFF
--- a/infrastructure/logging/logging.go
+++ b/infrastructure/logging/logging.go
@@ -105,7 +105,7 @@ func createLogDir() error {
 	}
 
 	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
-		err := os.Mkdir(dirPath, 0755)
+		err := os.MkdirAll(dirPath, 0755)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Changelog**

Fixed logging bug

**Bugfixes**

Fixed fatal caused by Mkdir instead of MkdirAll

**Notes**

Steps to reproduce:
1) rm -fr ~/Library/logs/Leapp (or any parent dir)
2) go run main.go